### PR TITLE
Fix coherence

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,6 +16,7 @@ $recipes = $statement->fetchAll(PDO::FETCH_ASSOC);
         <title>List of Recipes</title>
     </head>
     <body>
+        <a href="/add.php">Add</a>
         <h1>List of Recipes</h1>
         <ul>
             <?php foreach ($recipes as $recipe) : ?>


### PR DESCRIPTION
Fix cohérence entre l'énoncé et le code cloné (le lien add est dans l'énoncé mais pas dans le fichier, selon ce qu'on c/c à l'éxo 1, on a le lien, et parfois non).